### PR TITLE
Dont override jobs by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.14"
+  - "1.16"
   - "tip"
 
 script:

--- a/enqueue.go
+++ b/enqueue.go
@@ -148,9 +148,7 @@ func trySetNewDescJob(
 		if err == nil {
 			otherDesc := JobDesc{}
 			err := json.Unmarshal(otherDescJson, &otherDesc)
-			// The job is still waiting to be executed for the first time,
-			// return it
-			if err == nil && otherDesc.IsInitWaiting() {
+			if err == nil && !otherDesc.CanBeOverridden() {
 				return &otherDesc, err
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PlanitarInc/go-workers-once
 
-go 1.14
+go 1.16
 
 require (
 	github.com/PlanitarInc/go-workers v0.0.0-20200511175112-adc6d1827aba

--- a/job-descriptor.go
+++ b/job-descriptor.go
@@ -29,6 +29,7 @@ type JobDesc struct {
 type Options struct {
 	workers.EnqueueOptions
 	AtMostOnce       bool `json:"at_most_once"`
+	OverrideStarted  bool `json:"override_started"`
 	InitWaitTime     int  `json:"init_wait"`
 	RetryWaitTime    int  `json:"retry_wait"`
 	ExecWaitTime     int  `json:"exec_wait"`
@@ -82,6 +83,12 @@ func NewJobDesc(jid, queue, jobType string, opts *Options) *JobDesc {
 		CreatedMs: time2ms(time.Now()),
 		Options:   optionsMergeDefaults(opts),
 	}
+}
+
+func (d JobDesc) CanBeOverridden() bool {
+	// If OverrideStarted is set, we can override the task already started.
+	// Otherwise we have to wait until the task is removed from Redis.
+	return d.Options != nil && d.Options.OverrideStarted && d.Status != StatusInitWaiting
 }
 
 func (d JobDesc) IsInitWaiting() bool {


### PR DESCRIPTION
This PR partially reverts https://github.com/PlanitarInc/go-workers-once/pull/4.

### Background

The original behaviour was to avoid scheduling new jobs if there is an existing one. That is if there exists a job descriptor we will never schedule a new job. The job can be actually done by that time and be stored only because of its FailureRetention/SuccessRetention value. See the state chart below. Every state has a timeout specified in parenthesis, when this timeout is exceeded the job is being purged and will never get executed. A new job can be scheduled if there is no stored job.

```
             | on schedule
             V
     +----------------+
     | init-waiting   |
     | (InitWaitTime) |
     +----------------+
             |
             | on run
             |
             |    +---------------------+
             |    |                     | on retry
             V    V                     |
     +----------------+         +----------------+ 
     |   executing    |         | retry-waiting  |
     | (ExecWaitTime) |         | (RetryWaitTime)|
     +----------------+         +----------------+
             |                          A
             | on done                  | can retry
             |        if failed         |
             +--------->----------------+
             |                          |
             | if suceeded              | cannot retry
             |                          |
             V                          V
    +--------------------+   +--------------------+
    |         ok         |   |      failed        |
    | (SuccessRetention) |   | (FailureRetention) |
    +--------------------+   +--------------------+
```

This design was intentional as it allowed more fine-grained tuning. But we never used it properly in practice. This just caused a lot of confusion.

As a result, https://github.com/PlanitarInc/go-workers-once/pull/4 change the behaviour to:
1. If there is a job and it has not started yet, don't schedule a new one
2. otherwise, allow scheduling a new job

This new behaviour ensured that a request to run a job is never "lost".

The original behaviour assumed that jobs scheduled "approximately" at the same time are the same (a new job scheduled when there is an active one can be discarded). This is a reasonable assumption under some circumstances.

The new behaviour assumes that any request to run a job obsoletes the currently running one. For example, the currently running job is outdated because the underlying data in DB has changed and hence a new job should never be discarded. This is a reasonable assumption as well -- it brings us closer to "debounce" semantics.

The main problem with the new behaviour is that it breaks the "at-most-once" semantics. For example, the same scenario would end up with completely different results. The events are denoted as `x` and mean requests to run a job.

The original behaviour ensures that at most one jobs executes at a time:

```
 Events:   x  x           x x  x x 
           |              |
 Jobs:     S==job1==D     S==job2==D
               job 1      job 2
```

The new behaviour ensures no request is lost:

```
 Events:   x  x           x x  x x 
           |  |           | |  | |
 Jobs:     S==job1==D     S==job3==D
              S==job2==D    S==job4==D
                               S==job5==D
                                 S==job6==D
```

### Solution

There are situations where the original behaviour is preferred and there are situations where the new behaviour is preferred. The robust solution is to implement proper "debounce" semantics. It could provide us with both guarantees: (i) at most one job is running, (ii) no job request is lost. In the above example, it would result in:

```
                                    (Ideal solution with proper debounce semantics)
 Events:   x  x           x x  x x 
           |              |
 Jobs:     S==job1==D     S==job3==D              S==job4==D
                                    |------------|
                                    cooling period
```

Unfortunately, it is not worth the effort yet. So the comprise solution is to provide both behaviours and let the user of this library choose ad-hoc which one should be used. Since the name of the library implies that it provides "at-most-once" semantics in the first place, the default behaviour is to set to "at-most-once". But the user could choose to use "no-job-loss" behaviour by setting the `OverrideStarted` flag.

Related to https://github.com/PlanitarInc/go-workers-once/pull/4