### PR TITLE
Add UpdatedMs when adding new Job

### DIFF
--- a/job-descriptor.go
+++ b/job-descriptor.go
@@ -75,15 +75,15 @@ func optionsMergeDefaults(opts *Options) *Options {
 }
 
 func NewJobDesc(jid, queue, jobType string, opts *Options) *JobDesc {
-	curTime2ms := time2ms(time.Now())
+	nowMs := time2ms(time.Now())
 
 	return &JobDesc{
 		Jid:       jid,
 		Status:    StatusInitWaiting,
 		Queue:     queue,
 		JobType:   jobType,
-		CreatedMs: curTime2ms,
-		UpdatedMs: curTime2ms,
+		CreatedMs: nowMs,
+		UpdatedMs: nowMs,
 		Options:   optionsMergeDefaults(opts),
 	}
 }

--- a/job-descriptor_test.go
+++ b/job-descriptor_test.go
@@ -72,5 +72,5 @@ func TestNewJobDesc(t *testing.T) {
 
 	nowMs := time2ms(time.Now())
 	Ω(d.CreatedMs).Should(BeBetween(nowMs-100, nowMs+100))
-	Ω(d.UpdatedMs).Should(BeBetween(nowMs-100, nowMs+100))
+	Ω(d.UpdatedMs).Should(Equal(d.CreatedMs))
 }


### PR DESCRIPTION
This PR works on a bug that can cause when a new job is created or enqueued. As we are not explicitly setting UpdatedMs when a job is enqueued, this can cause the updatedMs property to hold zero value for time (year 1969). Which will always be before an enqueued at time set.

Original bug was noticed on https://github.com/PlanitarInc/walk-inside-api/pull/1081